### PR TITLE
fix links to tarballs in xc tutorial

### DIFF
--- a/docs/workshop/04_nmr_shiedling_efg.md
+++ b/docs/workshop/04_nmr_shiedling_efg.md
@@ -203,8 +203,8 @@ INSTRUCTIONS:
 |&#948;(A)-&#948; (B) (ppm)| 23.5|
 |C<sub>Q</sub> (A) (MHz)| 7.86|
 |&#951;<sub>Q</sub> (A)| 0.28|
-|C<sub>Q</sub>(A) (MHz)| 6.53|
-|&#951;<sub>Q</sub>(A)| 0.70|
+|C<sub>Q</sub>(B) (MHz)| 6.53|
+|&#951;<sub>Q</sub>(B)| 0.70|
 
 
 

--- a/docs/workshop/07_xc.md
+++ b/docs/workshop/07_xc.md
@@ -38,7 +38,7 @@ $ castep -help search all
 
 In this first exercise, we shall explore how to use different XC functionals to determine the electronic structure of silicon. 
 
-1. Get the files required for this exercise : (Si2 files)[ Attach:Si2.tar.gz]
+1. Get the files required for this exercise : [Si2 files](Si2.tar.gz)
  
 	We shall carry out these calculations on arcus. Transfer the files to arcus, and unzip and untar them. You can use:
 	
@@ -152,7 +152,7 @@ We shall now move onto examining what happens with a non-local functional. In pr
 
 In the XC Functional talk, data were shown illustrating the effect of functional upon the electronic structure of antiferromagnetic FeO. In this example you will learn how to perform DFT+U calculations. 
 
-1. Get the files required for this exercise : [FeO Files]( Attach:FeO.tar.gz)
+1. Get the files required for this exercise : [FeO Files](FeO.tar.gz)
  
 	We shall carry out these calculations on arcus. Transfer the files to arcus, and unzip and untar them. 
 
@@ -220,7 +220,7 @@ In the XC Functional talk, data were shown illustrating the effect of functional
 
 Graphite represents a prototypical example of a layered system in which the layers are weakly bound by van der Waals forces. As is well known, local and semi-local functionals such as the LDA and GGA neglect such interactions, and we could perhaps anticipate that they therefore perform poorly for such a system. We will explore the performance of these functionals. This example will also show you how to run dispersion corrected DFT+D functionals. 
 
-1. Get the files required for this exercise : [Graphite files](Attach:Graphite.tar.gz)
+1. Get the files required for this exercise : [Graphite files](Graphite.tar.gz)
  
 	As before, we shall carry out these calculations on arcus. Transfer the files to arcus, and unzip and untar them. 
 


### PR DESCRIPTION
The links to the tarballs in the XC tutorial currently don't work -- this PR fixes the links on my local installation.

There was also a small typo in the NMR tutorial.